### PR TITLE
example.co.jp のようにトップレベルドメインが2要素の場合, ホストゾーン ID の parse に不具合が出る問題を修正.

### DIFF
--- a/certbot_dns_route53_less/_internal/dns_route53.py
+++ b/certbot_dns_route53_less/_internal/dns_route53.py
@@ -95,8 +95,8 @@ class Authenticator(dns_common.DNSAuthenticator):
             zone_id = zone_infos[1].strip()
             zone_ids[zone_domain] = zone_id
 
-        zone_domain = '.'.join(domain.split('.')[1:])
-        zone = zone_ids[zone_domain]
+        requested_domain = '.'.join(domain.split('.')[1:])
+        zone = zone_ids[requested_domain]
 
         if not zone:
             raise errors.PluginError(

--- a/certbot_dns_route53_less/_internal/dns_route53.py
+++ b/certbot_dns_route53_less/_internal/dns_route53.py
@@ -95,8 +95,8 @@ class Authenticator(dns_common.DNSAuthenticator):
             zone_id = zone_infos[1].strip()
             zone_ids[zone_domain] = zone_id
 
-        domain = '.'.join(domain.split('.')[-2:])
-        zone = zone_ids[domain]
+        zone_domain = '.'.join(domain.split('.')[1:])
+        zone = zone_ids[zone_domain]
 
         if not zone:
             raise errors.PluginError(

--- a/certbot_dns_route53_less/_internal/dns_route53.py
+++ b/certbot_dns_route53_less/_internal/dns_route53.py
@@ -91,9 +91,9 @@ class Authenticator(dns_common.DNSAuthenticator):
         zone_ids = dict()
         for zone_info in self.conf('zone-ids').split(','):
             zone_infos = zone_info.split('=')
-            domain = zone_infos[0].strip()
+            zone_domain = zone_infos[0].strip()
             zone_id = zone_infos[1].strip()
-            zone_ids[domain] = zone_id
+            zone_ids[zone_domain] = zone_id
 
         domain = '.'.join(domain.split('.')[-2:])
         zone = zone_ids[domain]


### PR DESCRIPTION
### 概要

`example.co.jp` のようにトップレベルドメインが2要素の場合, 関数 `_find_zone_id_for_domain` 内の辞書変数 `zone_ids` にアクセスする際, `zone_ids["co.jp"]' となる不具合があったので修正しました.

また, 関数 `_find_zone_id_for_domain` の引数 domain と同じ名前の変数が for で使われて上書きされていたので, 新たな変数 `zone_domain` を用意しました.